### PR TITLE
Coro dependency

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 Revision history for Perl extension RabbitFoot
 
+        - Avoid (additional) issues when in global destruction.
         - Do not set reply_to to an empty string in the header frame.
 
 1.02    Wed Jun 30 11:35:32 2010

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,8 +12,6 @@ requires 'JSON::XS';
 requires 'List::MoreUtils';
 requires 'Net::AMQP';
 requires 'AnyEvent';
-requires 'Coro';
-requires 'Coro::AnyEvent';
 requires 'File::ShareDir';
 
 requires 'Devel::GlobalDestruction';

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,6 +16,9 @@ requires 'Coro';
 requires 'Coro::AnyEvent';
 requires 'File::ShareDir';
 
+requires 'Devel::GlobalDestruction';
+requires 'namespace::clean';
+
 tests 't/*.t';
 author_tests 'xt';
 install_share;

--- a/lib/AnyEvent/RabbitMQ.pm
+++ b/lib/AnyEvent/RabbitMQ.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Data::Dumper;
+use Carp qw/ confess /;
 use List::MoreUtils qw(none);
 
 use AnyEvent::Handle;
@@ -57,6 +58,10 @@ sub connect {
     $args{on_close}        ||= sub {};
     $args{on_read_failure} ||= sub {warn @_, "\n"};
     $args{timeout}         ||= 0;
+
+    for (qw/ host port /) {
+        confess("No $_ passed to connect to") unless $args{$_};
+    }
 
     if ($self->{verbose}) {
         warn 'connect to ', $args{host}, ':', $args{port}, '...', "\n";

--- a/lib/AnyEvent/RabbitMQ.pm
+++ b/lib/AnyEvent/RabbitMQ.pm
@@ -16,6 +16,9 @@ use Net::AMQP::Common qw(:all);
 use AnyEvent::RabbitMQ::Channel;
 use AnyEvent::RabbitMQ::LocalQueue;
 
+use Devel::GlobalDestruction;
+use namespace::clean;
+
 our $VERSION = '1.02';
 
 sub new {
@@ -454,7 +457,7 @@ sub _set_cbs {
     my %args = @_;
 
     $args{on_success} ||= sub {};
-    $args{on_failure} ||= sub {die @_};
+    $args{on_failure} ||= sub { return if in_global_destruction; die @_};
 
     return %args;
 }

--- a/xt/05_coro.t
+++ b/xt/05_coro.t
@@ -35,7 +35,7 @@ my $rf = Net::RabbitFoot->new();
 lives_ok sub {
     $rf->load_xml_spec(Net::RabbitFoot::default_amqp_spec())
 }, 'load xml spec';
- 
+
 lives_ok sub {
     $rf->connect(
         (map {$_ => $conf->{$_}} qw(host port user pass vhost)),


### PR DESCRIPTION
Hiya

I mostly use the fully async AnyEvent::RabbitFoot in my software, and I'm not otherwise using Coro.

Whilst Coro can be useful in clients (as demonstrated in the xt/ tests) if you're not being fully non-blocking, I would like to avoid depending on it (and would like to be able to deploy Net::RabbitFoot in environments and perl versions where Coro doesn't work).

Therefore I've made some fairly simple changes to Net::RabbitFoot to use plain AnyEvent condvars instead of Coro rouse_wait callbacks. From my testing this seems to work equally well (both in places where I am and am not using Coro in conjunction with Net::RabbitFoot).

Can you let me know what you think of this patch (i.e. if it's acceptable to take upstream, and if not - why not)?

Thanks in advance.
t0m
