### PR TITLE
AnyEvent::RabbitMQ 1.03 should be required

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,7 +10,7 @@ requires 'MooseX::ConfigFromFile';
 requires 'Config::Any';
 requires 'JSON::XS';
 requires 'List::MoreUtils';
-requires 'AnyEvent::RabbitMQ';
+requires 'AnyEvent::RabbitMQ' => '1.03';
 requires 'Coro';
 requires 'Coro::AnyEvent';
 


### PR DESCRIPTION
Otherise ->load_xml_spec() expects a filename, which doesn't work in the
earlier version
