### PR TITLE
Add missing dependency to insall using cpanminus

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,6 +7,7 @@ requires 'Moose';
 requires 'MooseX::AttributeHelpers';
 requires 'MooseX::App::Cmd';
 requires 'MooseX::ConfigFromFile';
+requires 'MooseX::Getopt';
 requires 'Config::Any';
 requires 'JSON::XS';
 requires 'List::MoreUtils';


### PR DESCRIPTION
This will solve the failing tests when installing:

```
#   Failed test 'use Net::RabbitFoot::Cmd::Command::declare_queue;'
#   at t/00_compile.t line 11.
#     Tried to use 'Net::RabbitFoot::Cmd::Command::declare_queue'.
#     Error:  Can't locate MooseX/Getopt.pm in @INC (...) at .../Module/Runtime.pm line 317.
```
